### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,7 +4,7 @@ author=Luc Chouinard
 maintainer=Luc Chouinard
 sentence=Console dummy like class that implement linenoise
 paragraph=
-category=Console CLI Command LINE
+category=Other
 url=https://github.com/lumostor/arduino-esp32-console.git
 architectures=esp32
 


### PR DESCRIPTION
WARNING: Category 'Console CLI Command LINE' in library Console is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format